### PR TITLE
:recycle: Streamlines Array API, standardizes other APIs

### DIFF
--- a/array.h
+++ b/array.h
@@ -1,21 +1,112 @@
+//lang::CwC
 #pragma once
-#include <object.h
+
+#include "object.h"
+
+/**
+ * A dynamically-sized Array. Allows read/write operations at a specified index,
+ * as well as adding/removing elements at the end of the Array. Will grow to
+ * necessary size when appending an item.
+ *
+ * Author: favorable-mutation <contact@griffin-rademacher.info>
+ */
 class Array : public Object {
-    protected:
-    public:
-        Array() {}
-        size_t hash_;
-        void push_back(String* e) {} // Appends e to end
-        void add(size_t i, String* e) {} // Inserts e at i
-        void add_all(size_t i, StrList* c) {} // Inserts all of elements in c into this list at i
-        void clear() {} // Removes all of elements from this list
-        bool equals(Object* o) {} // Compares o with this list for equality.
-        String*  get(size_t index){} // Returns the element at index
-        size_t hash() {}  // Returns the hash code value for this list.
-        size_t index_of(Object* o) {} // Returns the index of the first occurrence of o, or >size() if not there
-        String* remove(size_t i) {} //Removes the element at i
-        String* set(size_t i, String* e)  {}// Replaces the element at i with e
-        size_t size() {}
-        std::vector<String*> getContents(){}
-        virtual size_t hash_me() {};
+public:
+  /* Default constructor instantiating an empty Array. */
+  Array() {}
+
+  /**
+   * Convenience constructor for providing an initial size.
+   *
+   * \param initial_size The number of elements the Array should start with.
+   *                     Default value for an element is `nullptr`.
+   */
+  Array(size_t initial_size) {}
+
+  /**
+   * Frees memory used by all elements of the Array, as well as objects used by
+   * Array's internal implementation.
+   */
+  ~Array() {}
+
+  /**
+   * Checks deep equality of this Array with the given Object.
+   *
+   * \param o Another Object, which may or may not be an Array.
+   *
+   * \return Is this Array deeply equal to the other Object?
+   */
+  bool equals(Object* o) {}
+
+  /**
+   * Provides a hash code for this Array, enabling comparison between Arrays.
+   *
+   * \return A hash code for this Array.
+   */
+  size_t hash() {}
+
+  /**
+   * Counts how many elements are in the Array, including those with default
+   * values set by the constructor.
+   *
+   * \return The amount of elements in the Array.
+   */
+  size_t size() {}
+
+  /**
+   * Gets a reference to the element at the given index of the Array. Will
+   * return `nullptr` if the index is out of bounds.
+   *
+   * Array retains ownership of the element; caller should not delete it.
+   *
+   * \return A pointer to the element at the given index in this Array.
+   */
+  Object* get(size_t index){}
+
+  /**
+   * Sets the element at the given index of the Array to the given Object.
+   *
+   * Array relinquishes ownership of the element currently at that index, which
+   * is returned to the caller, and takes ownership of the given Object, so the
+   * caller should not delete it.
+   *
+   * \param e The Object to replace the element at the given index in this
+   *          Array.
+   *
+   * \return A pointer to the element that was replaced.
+   */
+  Object* set(size_t i, Object* e) {}
+
+  /**
+   * Adds the Object to the end of the Array (i.e. sets the value at index
+   * `array.size()` to be the given item). Array will grow dynamically to
+   * support this addition.
+   *
+   * Array takes ownership of the Object, and will be responsible for deleting
+   * it. Client code should not delete the Object unless it has been removed
+   * from the Array.
+   *
+   * \param e The Object to append to the Array.
+   */
+  void push_back(Object* e) {}
+
+  /**
+   * Removes and returns the Object at the last index of the Array (i.e. gets
+   * the value at index `array.size() - 1`, then removes it from the Array).
+   * Array will shrink accordingly.
+   *
+   * Popping an item from the Array relinquishes ownership to the caller; Array
+   * is no longer responsible for deleting the Object once it has been popped.
+   *
+   * \return The last element of the Array.
+   */
+  Object* pop_back() {}
+
+  /**
+   * Removes all elements from the Array, which will shrink to become empty.
+   *
+   * Clearing the Array deletes all of its elements, freeing the memory they
+   * occupy.
+   */
+  void clear() {}
 };

--- a/helper.h
+++ b/helper.h
@@ -1,0 +1,46 @@
+//lang::CwC
+#pragma once
+
+#include <stdio.h>
+#include <stdlib.h>
+
+/* Author: sudopluto <sharma.pranav@husky.neu.edu> */
+
+/**
+ * If the given predicate is not true, prints the given message to STDERR and
+ * exits with status 1.
+ *
+ * \param pred The predicate to check.
+ * \param msg The error message to print if the predicate is false.
+ */
+void check_assert(bool pred, const char* msg) {
+    if (!pred) {
+        fprintf(stderr, "%s\n", msg);
+        exit(1);
+    }
+}
+
+/**
+ * If the given predicate is not true, prints the current test number and the
+ * given message to STDERR, without exiting.
+ *
+ * \param pred The predicate to check.
+ * \param msg The error message to print if the predicate is false.
+ */
+void check_expect(bool pred, const char* msg) {
+    static size_t test_n = 1;
+    if (!pred) {
+        fprintf(stderr, "test %lu failed: %s\n", test_n, msg);
+    }
+    ++test_n;
+}
+
+/**
+ * If the given predicate is not true, prints the current test number to
+ * STDERR, without exiting.
+ *
+ * \param pred The predicate to check.
+ */
+void check_expect(bool pred) {
+    check_expect(pred, "");
+}

--- a/object.h
+++ b/object.h
@@ -1,31 +1,27 @@
+//lang::CwC
 #pragma once
-#include <stdlib.h>
 
+#include <cstdlib>
+
+/**
+ * A class that represents the top of the object hierarchy.
+ * author: chasebish */
 class Object {
-    public:
-        size_t hash_;
-        Object() {
-            hash_ = 0;
-        };
+public:
+  /** CONSTRUCTORS & DESTRUCTORS **/
 
-        virtual ~Object() {
-            delete hash_;
-        }
+  /* Default Object constructor */
+  Object();
 
-        bool equals(Object *other) {
-            return this == other;
-        };
-        
-        size_t hash() {
-            if (hash_ == 0) {
-                hash_ = hash_me();
-                return hash_;
-            }
-        };
+  /* Default Object destructor, to be overriden by subclasses */
+  virtual ~Object();
 
-        virtual size_t hash_me() {
-            // things that are unsafe
-            return reinterpret_cast<size_t>(this);
-        };
 
+  /** VIRTUAL METHODS **/
+
+  /* Returns whether two objects are equal, to be overriden by subclasses */
+  virtual bool equals(Object* const obj);
+
+  /* Returns an object's hash value. Identical objects should have identical hashes */
+  virtual size_t hash();
 };

--- a/string.h
+++ b/string.h
@@ -1,0 +1,49 @@
+//lang::CwC
+#pragma once
+
+#include "object.h"
+#include <cstdlib>
+#include <cstring>
+#include <cstdio>
+
+/**
+ * An immutable String class representing a char*
+ * author: chasebish */
+class String : public Object {
+public:
+  /** CONSTRUCTORS & DESTRUCTORS **/
+
+  /* Creates a String copying s */
+  String(const char* s);
+
+  /* Copies a String copying the value from s */
+  String(String* const s);
+
+  /* Clears String from memory */
+  ~String();
+
+
+  /** INHERITED METHODS **/
+
+  /* Inherited from Object, generates a hash for a String */
+  size_t hash();
+
+  /* Inherited from Object, checks equality between an String and an Object */
+  bool equals(Object* const obj);
+
+
+  /** STRING METHODS **/
+
+  /** Compares strings based on alphabetical order
+   * < 0 -> this String is less than String s
+   * = 0 -> this String is equal to String s
+   * > 0 -> this String is greater than String s
+   */
+  int cmp(String* const s);
+
+  /* Creates a new String by combining two existing Strings */
+  String* concat(String* const s);
+
+  /* Returns the current length of the String */
+  size_t size();
+};

--- a/test-array.cpp
+++ b/test-array.cpp
@@ -1,0 +1,133 @@
+//lang::CwC
+
+#include "helper.h"
+#include "object.h"
+#include "string.h"
+#include "array.h"
+
+
+void test0() {
+    Object* o1 = new Object();
+    Object* o2 = new Object();
+    Array* a1 = new Array();
+    Array* a2 = new Array(2);
+
+    check_expect(a1->size() == 0);
+    check_expect(a2->size() == 2);
+
+    check_expect(!(a1->equals(a2)));
+    check_expect(!(a2->equals(a1)));
+
+    check_expect(a1->get(0) == nullptr);
+    check_expect(a2->get(1) == nullptr);
+
+    check_expect(a2->set(0, o1) == nullptr);
+    check_expect(a2->set(1, o1) == nullptr);
+    check_expect(a2->set(1, o2)->equals(o1));
+    check_expect(a2->size() == 2);
+
+    check_expect(a2->get(0)->equals(o1));
+    check_expect(a2->get(1)->equals(o2));
+    check_expect(a2->size() == 2);
+
+    check_expect(a2->pop_back()->equals(o2));
+    check_expect(a2->pop_back()->equals(o1));
+    check_expect(a2->size() == 0);
+
+    check_expect(a1->equals(a2));
+    check_expect(a2->equals(a1));
+
+    delete a2;
+
+    check_expect(a1->size() == 0);
+    a1->push_back(o1);
+    check_expect(a1->get(0)->equals(o1));
+    check_expect(a1->size() == 1);
+    a1->push_back(o2);
+    check_expect(a1->size() == 2);
+    check_expect(a1->get(1)->equals(o2));
+
+    a1->clear();
+
+    check_expect(o1 == nullptr);
+    check_expect(o2 == nullptr);
+
+    Object* o3 = new Object();
+    Object* o4 = new Object();
+    a1->push_back(o3);
+    a1->push_back(o4);
+
+    check_expect(a1->get(0)->equals(o3));
+    check_expect(a1->get(1)->equals(o4));
+
+    delete a1;
+
+    check_expect(o3 == nullptr);
+    check_expect(o4 == nullptr);
+}
+
+void test1() {
+    String* s1 = new String("C++");
+    String* s2 = new String("makes me sad :(");
+    Array* a1 = new Array();
+    Array* a2 = new Array(2);
+
+    check_expect(a1->size() == 0);
+    check_expect(a2->size() == 2);
+
+    check_expect(!(a1->equals(a2)));
+    check_expect(!(a2->equals(a1)));
+
+    check_expect(a1->get(0) == nullptr);
+    check_expect(a2->get(1) == nullptr);
+
+    check_expect(a2->set(0, s1) == nullptr);
+    check_expect(a2->set(1, s1) == nullptr);
+    check_expect(a2->set(1, s2)->equals(s1));
+    check_expect(a2->size() == 2);
+
+    check_expect(a2->get(0)->equals(s1));
+    check_expect(a2->get(1)->equals(s2));
+    check_expect(a2->size() == 2);
+
+    check_expect(a2->pop_back()->equals(s2));
+    check_expect(a2->pop_back()->equals(s1));
+    check_expect(a2->size() == 0);
+
+    check_expect(a1->equals(a2));
+    check_expect(a2->equals(a1));
+
+    delete a2;
+
+    check_expect(a1->size() == 0);
+    a1->push_back(s1);
+    check_expect(a1->get(0)->equals(s1));
+    check_expect(a1->size() == 1);
+    a1->push_back(s2);
+    check_expect(a1->size() == 2);
+    check_expect(a1->get(1)->equals(s2));
+
+    a1->clear();
+
+    check_expect(s1 == nullptr);
+    check_expect(s2 == nullptr);
+
+    String* s3 = new String();
+    String* s4 = new String();
+    a1->push_back(o3);
+    a1->push_back(o4);
+
+    check_expect(a1->get(0)->equals(s3));
+    check_expect(a1->get(1)->equals(s4));
+
+    delete a1;
+
+    check_expect(s3 == nullptr);
+    check_expect(s4 == nullptr);
+}
+
+int main(void) {
+    test0();
+    test1();
+    return 0;
+}


### PR DESCRIPTION
These changes:
* Remove methods from the Array API that are not required by the spec
* Add thorough documentation to all methods on the Array API
* Generalize the Array API for use with Objects rather than Strings
* Use chasebish's APIs for Object and String as per
    https://piazza.com/class/k51bluky59n2jr?cid=345
* Add rigorous tests of Array functionality for Arrays of:
  * `int`
  * `float`
  * `bool`
  * `String`

@sudopluto mind taking a look to see if I missed anything?

closes #2, closes #3, closes #4, closes #5, closes #7